### PR TITLE
fix the seed hash to fit the code of nodes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
 };
 
 export const INITIAL_SESSION_TIMEOUT = 5
-export const MAINNET_BYTE = 'W'.charCodeAt(0);
+export const MAINNET_BYTE = 'M'.charCodeAt(0);
 export const TESTNET_BYTE = 'T'.charCodeAt(0);
 export const INITIAL_NONCE = 0;
 export const ADDRESS_VERSION = 5;

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -35,8 +35,8 @@ function hashChain(input) {
     return keccak(blake2b(input));
 }
 function buildSeedHash(seed, nonce) {
-    var seedNoceStr = nonce.toString() + seed
-    var seedBytesWithNonce = Uint8Array.from(converters_1.default.stringToByteArray(seedNoceStr));
+    var seedNonceStr = nonce.toString() + seed
+    var seedBytesWithNonce = Uint8Array.from(converters_1.default.stringToByteArray(seedNonceStr));
     var seedHash = hashChain(seedBytesWithNonce);
     return sha256(seedHash);
 }


### PR DESCRIPTION
Change in ```crypto.js```

```
origin: byte array concat (byte array of seed string , byte array of nonce integer)
now: byte array of string concat (seed string, nonce integer to string)
```

according to [codes of wallet generator](https://github.com/excelsia/wallet-generator/blob/master/src/main/scala/WalletGenerator.scala#L325-L327)
```
      val nonce : Long = lastNonce + n - 1
      val noncedSeed = nonce.toString + seed
      val accountSeedHash = hashChain(noncedSeed.getBytes("UTF-8"))
```